### PR TITLE
Clean Empty

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,3 +99,11 @@ verification. User IDs come from the URL path (`/v2/users/{userID}/sessions`).
 
 - Read `docs/go-conventions.md` before reviewing Go code — it covers idioms like consumer-defined interfaces and `panic`
   for invariants.
+
+## Reviewing
+
+Before flagging a function's behavior as a risk, trace its full call chain. A function may look problematic in isolation
+but be harmless given the guarantees its callers already enforce. For example, `DigestSessionName` has a "false
+positive"
+risk if you read it alone, but every caller only feeds it sessions that are already known to be empty — so a misparse
+is harmless. Always verify the data flow from source to sink before concluding something is a bug.

--- a/README.md
+++ b/README.md
@@ -94,3 +94,7 @@ asserting the request access endpoints such as /users/{userID}/sessions have the
 
 Such a mechanism is simplest in the current project.
 And there is an auth in amah, I don't want to copy and paste that module.
+
+### GORM GEN vs CLI
+
+See `docs/decisions/gorm.md`.

--- a/clients/model/meta.go
+++ b/clients/model/meta.go
@@ -15,3 +15,11 @@ type SessionChatQuery[T any] interface {
 	// ORDER BY chats.session_id;
 	FindChatPartByUserID(userID int) ([]ChatPart, error)
 }
+
+type Session struct {
+	ID       int `json:"-"`
+	Name     string
+	UserID   int
+	ScopedID int
+	Chats    []*Chat `gorm:"foreignkey:SessionID"`
+}

--- a/clients/model/model.go
+++ b/clients/model/model.go
@@ -9,6 +9,7 @@ package model
 
 import (
 	"aiagent/clients/openai"
+	"strings"
 	"time"
 )
 
@@ -63,6 +64,21 @@ type SessionWithID struct {
 
 func DefaultSessionName() string {
 	return time.Now().String()
+}
+
+// WeakName returns whether the [Session.Name] is weak.
+// Weak indicates it's a poorly generated name by timestamp,
+// which should be improved by the digest mechanism.
+func (s *Session) WeakName() bool {
+	// The implementation is a reverse of [time.Time.String].
+	name := s.Name
+	index := strings.LastIndex(name, " m=")
+	if index != -1 {
+		name = name[:index]
+	}
+	// That layout used in [time.Time.String] is not exposed, so we forked a copy here.
+	_, err := time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", name)
+	return err == nil
 }
 
 func (s *Session) History() []openai.Message {

--- a/clients/model/model.go
+++ b/clients/model/model.go
@@ -68,10 +68,13 @@ func DefaultSessionName() string {
 
 // WeakName returns whether the [Session.Name] is weak.
 // Weak indicates it's a poorly generated name by timestamp,
-// which should be improved by the digest mechanism.
+// which have the potential to be improved by the digest mechanism.
 func (s *Session) WeakName() bool {
+	return SessionNameGeneratedFromTime(s.Name)
+}
+
+func SessionNameGeneratedFromTime(name string) bool {
 	// The implementation is a reverse of [time.Time.String].
-	name := s.Name
 	index := strings.LastIndex(name, " m=")
 	if index != -1 {
 		name = name[:index]

--- a/clients/model/model.go
+++ b/clients/model/model.go
@@ -70,18 +70,19 @@ func DefaultSessionName() string {
 // Weak indicates it's a poorly generated name by timestamp,
 // which have the potential to be improved by the digest mechanism.
 func (s *Session) WeakName() bool {
-	return SessionNameGeneratedFromTime(s.Name)
+	_, generatedFromTime := DigestSessionName(s.Name)
+	return generatedFromTime
 }
 
-func SessionNameGeneratedFromTime(name string) bool {
+func DigestSessionName(name string) (t time.Time, generatedFromTime bool) {
 	// The implementation is a reverse of [time.Time.String].
 	index := strings.LastIndex(name, " m=")
 	if index != -1 {
 		name = name[:index]
 	}
 	// That layout used in [time.Time.String] is not exposed, so we forked a copy here.
-	_, err := time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", name)
-	return err == nil
+	t, err := time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", name)
+	return t, err == nil
 }
 
 func (s *Session) History() []openai.Message {

--- a/clients/model/model.go
+++ b/clients/model/model.go
@@ -13,14 +13,6 @@ import (
 	"time"
 )
 
-type Session struct {
-	ID       int `json:"-"`
-	Name     string
-	UserID   int
-	ScopedID int
-	Chats    []*Chat `gorm:"foreignkey:SessionID"`
-}
-
 type SessionWithChatsDigest struct {
 	Session
 	ChatsDigest

--- a/clients/model/model_test.go
+++ b/clients/model/model_test.go
@@ -1,0 +1,25 @@
+package model
+
+import "testing"
+
+func TestSession_WeakName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"happy path", "2025-04-07 08:06:54.421831436 -0400 EDT m=+591042.754616192", true},
+		{"none", "", false},
+		{"manually defined", "this_is_a_session", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Session{
+				Name: tt.input,
+			}
+			if got := s.WeakName(); got != tt.want {
+				t.Errorf("WeakName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/clients/session/session.go
+++ b/clients/session/session.go
@@ -215,3 +215,37 @@ func (r *Repository) FindWithChatsDigestByUserID(
 
 	return extendSessionWithChatsDigest(sessions, digest(chats)), nil
 }
+
+func (r *Repository) FindEmptySessionIDToName(ctx context.Context) (sessionIDToName map[int]string, err error) {
+	var nonEmptySessionIDs []int
+	if err := r.q.Chat.WithContext(ctx).
+		Distinct(r.q.Chat.SessionID).
+		Pluck(r.q.Chat.SessionID, &nonEmptySessionIDs); err != nil {
+		return nil, err
+	}
+
+	sessions, err := r.q.Session.WithContext(ctx).
+		Where(r.q.Session.ID.NotIn(nonEmptySessionIDs...)).
+		Select(r.q.Session.ID, r.q.Session.Name).Find()
+	if err != nil {
+		return nil, err
+	}
+	return extractSessionIDToName(sessions), nil
+}
+
+func extractSessionIDToName(sessions []*model.Session) (sessionIDToName map[int]string) {
+	sessionIDToName = make(map[int]string)
+	for _, session := range sessions {
+		// session_id is PK, it's a bijection, can't override or lost item.
+		sessionIDToName[session.ID] = session.Name
+	}
+	return sessionIDToName
+}
+
+func (r *Repository) DeleteByIDs(ctx context.Context, ids ...int) error {
+	rowsAffected, err := gorm.G[model.Session](r.db).Where(generated.Session.ID.In(ids...)).Delete(ctx)
+	if err == nil {
+		slog.Info("deleted sessions", "count", rowsAffected, "ids", ids)
+	}
+	return err
+}

--- a/docs/decisions/gorm.md
+++ b/docs/decisions/gorm.md
@@ -1,0 +1,31 @@
+# GORM [GEN vs CLI](https://gorm.io/cli/cli_vs_gen.html)
+
+## Status
+
+Both of them have been practiced in this project.
+
+I am still evaluating them.
+
+## Goals
+
+What I want is typed.
+
+Then, generic SQL. Even though I don't need it now, I do value smooth transits between SQL dialects.
+
+## Issues
+
+As [it](https://gorm.io/cli/#GORM-CLI-Overview) defines, GORM CLI generates helpers for **common** model operations,
+which means occasionally there must be other approach on **less common** operations.
+
+If I fall back to GORM, then I lost something that GORM CLI is better than GORM.
+
+If I switch to GEN, then I miss something that GORM GEN has same to GORM CLI.
+
+Neither a stand-alone struct nor field name string literal shall I accepted to do a partial field select.
+
+## Policy
+
+If GORM CLI could work gracefully, I would choose it first at that task.
+
+Comparing to combining with GORM vanilla without typed or with string literal,
+I would rather use GORM GEN alone as long as it's more elegant in that task.

--- a/docs/go-conventions.md
+++ b/docs/go-conventions.md
@@ -20,6 +20,28 @@ This is idiomatic Go. Do not flag it as duplication or inconsistency.
 Consolidating them into one shared interface would violate interface
 segregation and couple unrelated packages.
 
+## Named Result Parameters as Documentation
+
+Naming a result parameter purely for documentation is acceptable, even if the
+body does not touch it. The name in the signature tells the reader what the
+returned value represents.
+
+When the named return is not used in the body, prefer a local variable over
+assigning to the named return directly. A local variable has a shorter,
+clearer life-cycle — the reader sees it declared and knows nothing mutates it
+before or after the visible update site. A named return lives for the whole
+function, which adds tracking overhead: the reader must scan backward and
+forward to confirm no other assignment touches it.
+
+```go
+// OK: name documents the result, local variable keeps body self-contained.
+func filterOldAndMapSessionIDs(m map[int]string) (sessionIDs []int) {
+var ret []int
+...
+return ret
+}
+```
+
 ## Panic for Invariants
 
 `panic` is used for invariant violations (fail-fast), not for ordinary

--- a/docs/samples.http
+++ b/docs/samples.http
@@ -56,4 +56,11 @@ POST {{host}}/v1/sessions/{{id}}/chat?stream=true
 GET {{host}}/v1/build-info
 Token: {{token}}
 
+### v1CleanEmpty
+
+POST {{host}}/v1/clean-empty
+Token: {{token}}
+
+This_is_a_message_from_caller.
+
 ###

--- a/docs/session.sql
+++ b/docs/session.sql
@@ -25,3 +25,8 @@ FROM chats
          LEFT JOIN sessions ON chats.session_id = sessions.id
 WHERE user_id = 1000
 ORDER BY chats.session_id;
+
+SELECT sessions.id, sessions.name, COUNT(chats.id) AS count
+FROM sessions
+         LEFT JOIN chats ON sessions.id = chats.session_id
+GROUP BY sessions.id;

--- a/service/v1.go
+++ b/service/v1.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/hyisen/wf"
 	"gorm.io/gorm"
@@ -60,4 +61,33 @@ func (s *V1Service) FindSessionByID(ctx context.Context, id int) (*model.Session
 		return nil, wf.NewCodedError(http.StatusInternalServerError, err)
 	}
 	return ret.WithID(), nil
+}
+
+func (s *V1Service) CleanEmptyOldSession(ctx context.Context) *wf.CodedError {
+	idToName, err := s.sessionRepository.FindEmptySessionIDToName(ctx)
+	if err != nil {
+		return wf.NewCodedError(http.StatusInternalServerError, err)
+	}
+	ids := filterOldAndMapSessionIDs(idToName)
+	err = s.sessionRepository.DeleteByIDs(ctx, ids...)
+	if err != nil {
+		return wf.NewCodedError(http.StatusInternalServerError, err)
+	}
+	return nil
+}
+
+func filterOldAndMapSessionIDs(sessionIDToName map[int]string) (sessionIDs []int) {
+	var ret []int
+	// Define sessions created such long time ago without chats are orphaned.
+	threshold := time.Now().Add(-time.Hour * 4)
+	for id, name := range sessionIDToName {
+		t, generatedFromTime := model.DigestSessionName(name)
+		if !generatedFromTime {
+			continue
+		}
+		if t.Before(threshold) {
+			ret = append(ret, id)
+		}
+	}
+	return ret
 }

--- a/service/v1.go
+++ b/service/v1.go
@@ -11,6 +11,10 @@ import (
 	"gorm.io/gorm"
 )
 
+// V1Service provides abilities without scoped_id constraint,
+// which makes it ideal for administrator actions, but not for normal users.
+// The V1 name does come from its earlier adoption,
+// but do not mean to be deprecated now nor in the future.
 type V1Service struct {
 	sessionRepository *session.Repository
 }

--- a/service/v2.go
+++ b/service/v2.go
@@ -11,6 +11,8 @@ import (
 	"gorm.io/gorm"
 )
 
+// V2Service provides abilities that similar to [V1Service], but with scoped_id constraint.
+// It's designed for normal users. Newer features may come to V2 first.
 type V2Service struct {
 	sessionRepository *session.Repository
 }

--- a/service/web.go
+++ b/service/web.go
@@ -7,6 +7,7 @@ import (
 	sc "aiagent/service/chat"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"reflect"
 	"runtime/debug"
@@ -209,6 +210,19 @@ func New(
 			return ret.buildInfo, nil
 		})
 
+	v1CleanEmpty := wf.NewClosureHandler(
+		wf.Exact(http.MethodPost, "/v1/clean-empty"),
+		func(data []byte, path string) (req any, err error) {
+			return string(data), nil
+		},
+		func(ctx context.Context, s any) (rsp any, codedError *wf.CodedError) {
+			slog.Info("triggered clean empty session", "msg", s.(string))
+			return nil, ret.v1.CleanEmptyOldSession(ctx)
+		},
+		wf.FormatEmpty,
+		http.DetectContentType(nil),
+	)
+
 	ret.web = wf.NewWeb(
 		false,
 		v1PostSession,
@@ -222,6 +236,7 @@ func New(
 		v2PostSessionChat,
 		v2PostSessionChatStream,
 		v1GetBuildInfo,
+		v1CleanEmpty,
 	)
 	return ret
 }


### PR DESCRIPTION
Some Session without Chats have been observed. 

ref commit 5c369c8968a78210cc168faf4669137fa12fafa1

It's caused by the create session first then add chat nature.

As decided, a curl trigger clean up action is implemented in CL.